### PR TITLE
Draft proposal for a o11y index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,50 @@
+# Observability index page
+
+This is a community driven index page for all things observability. There are several good materials all across the web. Blogs, videos, tutorials, books, documentation, and it can be difficult to find exactly what you are looking for.
+
+The aim of this page is to categorize and to serve as an index for the ones that the community see value.
+
+## Table of contents
+
+* [Written material](#writen-material)
+  * [Read time: 30 mins or less](#read-time-30-mins-or-less)
+  * [Read time: 30 mins up to 8 hours](#read-time-30-mins-up-to-8-hours)
+  * [Read time: more than 8 hours](#read-time-more-than-8-hours)
+* [Videos](#videos)
+* [Hands-on tutorials](#hands-on-tutorials)
+
+
+
+## Written material
+
+### Read time: 30 mins or less
+
+| Title                         | Author(s)                            | Publication date | Category  |
+|-------------------------------|--------------------------------------|------------------|-----------|
+| [Observability Maturity Report](https://cloud-native.slack.com/files/UPSTWGCBH/F01ER3VJY9Y/observability-maturity-report-4-3-2020-1-1.pdf) | ClearPath Strategies & honeycomb.io  | Q1, 2020         | Survey    |
+| [Monitoring and Observability](https://copyconstruct.medium.com/monitoring-and-observability-8417d1952e1c)  | Cindy Sridharan                      | Sep 5, 2017      | Blog post |
+
+### Read time: 30 mins up to 8 hours
+
+| Title                         | Author(s)                            | Publication date | Category  |
+|-------------------------------|--------------------------------------|------------------|-----------|
+| [Prometheus Docs](https://prometheus.io/docs/prometheus/latest/getting_started/) | Prometheus Authors  | Not applicable         | Docummentation    |
+| [Jaeger docs](https://www.jaegertracing.io/docs)  | Jaeger Authors                      | Not applicable      | Docummentation |
+
+
+### Read time: more than 8 hours
+| Title                         | Author(s)                            | Publication date | Category  |
+|-------------------------------|--------------------------------------|------------------|-----------|
+| [Site Reliability Handbook](https://landing.google.com/sre/sre-book/toc/) | Google, Inc.  | 2017         | Online Book    |
+
+
+## Videos
+| Title                         | Author(s)                            | Publication date | Category  |
+|-------------------------------|--------------------------------------|------------------|-----------|
+| [Observability 101](https://archive.fosdem.org/2019/schedule/event/on_observability_2019/) | Richard "RichiH" Hartmann | 2019 | Conference talk |
+
+## Hands-on tutorials
+
+| Title                         | Author(s)                            | Publication date | Category  |
+|-------------------------------|--------------------------------------|------------------|-----------|
+| [Learn Thanos](https://katacoda.com/thanos/courses/thanos) | Thanos Community | Not applicable | Interactive Tutorial |

--- a/index.md
+++ b/index.md
@@ -28,8 +28,8 @@ The aim of this page is to categorize and to serve as an index for the ones that
 
 | Title                         | Author(s)                            | Publication date | Category  |
 |-------------------------------|--------------------------------------|------------------|-----------|
-| [Prometheus Docs](https://prometheus.io/docs/prometheus/latest/getting_started/) | Prometheus Authors  | Not applicable         | Docummentation    |
-| [Jaeger docs](https://www.jaegertracing.io/docs)  | Jaeger Authors                      | Not applicable      | Docummentation |
+| [Prometheus Docs](https://prometheus.io/docs/prometheus/latest/getting_started/) | Prometheus Authors  | Not applicable         | Documentation    |
+| [Jaeger docs](https://www.jaegertracing.io/docs)  | Jaeger Authors                      | Not applicable      | Documentation |
 
 
 ### Read time: more than 8 hours


### PR DESCRIPTION
This is a draft proposal for #19 that I'd like to get some opinions on our next meeting.

What I'd like to discuss:
* What people think about this table-driven layout?

* Are we "collecting" materials about Observability only, or do we want project-specific as well? E.g., my questions at #18 were strongly related to Prometheus, do we want to provide the answer here or to leave it to the Prometheus team?

* How do we accept community contributions to this index? 
  * We probably would like to avoid pages that provide the same information
  * We probably would like to avoid pages with a non-inclusive language
  * Do we accept a new entry in which the contributor is not the author? E.g., me adding Richard's o11y 101 video.

We need a written guide with all the requirements to accept a new entry.



Signed-off-by: arthursens <arthursens2005@gmail.com>