### PR TITLE
replace deprecated landscape link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ supporting material and best practices for end-users and provides guidance and c
 
 ![projects](projects.png)
 
-Interactive Landscape: [here](https://landscape.cncf.io/category=observability-and-analysis&format=card-mode&grouping=category&project=hosted)
+Interactive Landscape: [here](https://landscape.cncf.io/card-mode?category=observability-and-analysis&grouping=category&project=hosted)
 
 ## How to get involved
 


### PR DESCRIPTION
when opening the current interactive landscape link the user is prompted that the current link is deprecated an a new (deep)link is available. this PR replaces the old link with the proposed one