### PR TITLE
Update charter following rename of SIG to TAG

### DIFF
--- a/observability-charter.md
+++ b/observability-charter.md
@@ -1,6 +1,6 @@
-# CNCF SIG Observability Charter
+# CNCF TAG Observability Charter
 
-- [CNCF SIG Observability Charter](#cncf-sig-observability-charter)
+- [CNCF TAG Observability Charter](#cncf-tag-observability-charter)
   - [Introduction](#introduction)
   - [Mission](#mission)
   - [Areas considered in Scope](#areas-considered-in-scope)
@@ -9,7 +9,7 @@
   - [Governance](#governance)
   - [Operations](#operations)
 
-*Review and contributions from:
+Review and contributions from:
 [Alex Nauda][Alex Nauda],
 [Alois Reitbauer][Alois Reitbauer],
 [Bartłomiej (Bartek) Płotka][Bartłomiej (Bartek) Płotka],
@@ -51,24 +51,24 @@ and [Umair Ishaq][Umair Ishaq].*
 ## Introduction
 
 This document describes the purpose and operations of the Cloud Native
-Computing Foundation ([CNCF]) Special Interest Group ([SIG]) on Observability.
+Computing Foundation ([CNCF]) Technical Advisory Group([TAG]) on Observability.
 
-This [SIG] focuses on topics pertaining to the observation
+This [TAG] focuses on topics pertaining to the observation
 of [cloud native][cn-def] workloads. Additionally, it produces supporting
 material and best practices for end-users and provides guidance and
-coordination for CNCF projects working within the SIG’s scope.
+coordination for CNCF projects working within the TAG’s scope.
 
 A full list of [CNCF projects][projs] can be found at [landscape.cncf.io].
 
 [cncf]: https://www.cncf.io
 [projs]: https://www.cncf.io/projects
 [landscape.cncf.io]: https://landscape.cncf.io
-[sig]:  https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md
-[cn-def]: https://github.com/cncf/toc/blob/master/DEFINITION.md
+[tag]:  https://github.com/cncf/toc/blob/main/tags/cncf-tags.md
+[cn-def]: https://github.com/cncf/toc/blob/main/DEFINITION.md
 
 ## Mission
 
-Consistent with the CNCF [SIG] definition, the mission of SIG Observability
+Consistent with the CNCF [TAG] definition, the mission of TAG Observability
 is to:
 
 - Foster and grow the ecosystem of observability related projects, users, and
@@ -84,7 +84,7 @@ is to:
 - Provide and maintain a vendor-neutral venue for relevant thought validation,
   discussion, and project feedback.
 - Provide a ladder for community members to become involved with the technical
-  oversight of projects within the SIG's scope in an open, transparent, and
+  oversight of projects within the TAG's scope in an open, transparent, and
   inclusive way.
 
 ## Areas considered in Scope
@@ -124,7 +124,7 @@ topics such as:
   like SLI/KPI, service objectives, and internal/external commitments.
 
 The following is a non-exhaustive sample list of activities and deliverables
-that are **in-scope** for this SIG
+that are in-scope for this TAG
 
 - Summary and overview of projects available in the community.
 - Catalog of reference architectures that draw from CNCF projects, combining
@@ -134,7 +134,7 @@ that are **in-scope** for this SIG
 - Tooling composition and toolchain creation based on existing projects.
 - Best practices for operations and monitoring workflows using CNCF Projects.
 - Organizing and helping to provide visibility to Meetups, Blogs, and Podcasts
-  related to the scope of the SIG.
+  related to the scope of the TAG.
 - Guidance for application development and architecture that is observable.
 - Replicatable reference architectures.
 - Patterns for observing application delivery pipelines.
@@ -154,55 +154,59 @@ Anything not explicitly considered in the scope above.
 Examples include:
 
 - Datastores that are not primarily used for observability. Those datastores
-  might be in the scope of SIG Storage.
+  might be in the scope of TAG Storage.
 - Security aspects that need to be present when setting up cloud native
-  infrastructure, these might be more relevant for SIG Security.
+  infrastructure, these might be more relevant for TAG Security.
 - How cloud native applications that need observability are deployed; this would
-  fall in the scope of SIG App Delivery.`
+  fall in the scope of TAG App Delivery
 - Tools and projects that are used to run cloud native workloads that in some
-  cases need observability would fall under the scope of SIG-Runtime.
+  cases need observability would fall under the scope of TAG-Runtime.
 
 ## Roadmap & Initial Efforts
 
-- Contribute to [due diligence reports][ddg] to assist the CNCF TOC for projects
-  in the scope of the SIG.
+- Contribute to Due Diligence (DD) Reviews in accordance with the TOC's
+  [Due Diligence Guidelines][ddg] and [Due Diligence Review Template][ddrt] to
+  assist the CNCF TOC for projects in the scope of the SIG.
 - Facilitate webinars and presentations from CNCF projects and domain experts in
-  the scope of the SIG.
-- Formation of [SIG working group(s)][sigwg] as resource capacity and member
+  the scope of the TAG.
+- Formation of [TAG working group(s)][tagwg] as resource capacity and member
   contribution allows.
 
-  > _SIGs may choose to spawn focussed and time-limited working groups to achieve some of their responsibilities (for example, to produce a specific educational white paper, or portfolio gap analysis report). Working groups should have a clearly documented charter, timeline (typically a few quarters at most), and set of deliverables. Once the timeline has elapsed, or the deliverables delivered, the working group dissolves, or is explicitly re-chartered._
+  > _TAGs may choose to spawn focussed and time-limited working groups to achieve some of their responsibilities (for example, to produce a specific educational white paper, or portfolio gap analysis report). Working groups should have a clearly documented charter, timeline (typically a few quarters at most), and set of deliverables. Once the timeline has elapsed, or the deliverables delivered, the working group dissolves, or is explicitly re-chartered._
 
 [ddg]: https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md
-[sigwg]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#responsibilities--empowerment-of-sigs
+[ddrt]: https://github.com/cncf/toc/blob/master/process/dd-review-template.md
+[tagwg]: https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#responsibilities--empowerment-of-tags
 
 ## Governance
 
-- This SIG follows the [standard operating model][som] provided by the TOC
+- This TAG follows the [standard operating model][som] provided by the TOC
   unless otherwise stated here.
 
-[som]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#operating-model
+[som]: https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model
 
 ## Operations
 
-- The formation of the SIG follows the [documented process][sigform].
-
-- [Roles][sigroles] for SIG Observability
-  - TOC Liaison: [Brendan Burns][Brendan Burns]
-  - SIG Chairs:
+- Formation of the TAG follows the [documented process][tagform].
+- [Roles][tagroles] for TAG Observability
+  - TOC Liaison: Lei Zhang, Cornelia Davis
+  - TAG Chairs:
     - [Matthew Young][matthew young]
     - [Richard Hartmann][Richard Hartmann]
     - TBD
-  - Tech Leads ([sigtlprocess])
+  - Tech Leads ([definition][tagtldefinition], [TL election][tagtlprocess])
     - Bartłomiej Płotka
+    - TBD more
 
-[sigform]: https://github.com/cncf/toc/tree/master/sigs#sig-formation-process
-[sigroles]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#sig-member-roles
-[sigtlprocess]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#elections
+[tagform]: https://github.com/cncf/toc/tree/main/tags#tag-formation-process
+[tagroles]: https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#tag-member-roles
+[tagtlprocess]: https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections
+[tagtldefinition]: https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#tech-lead
 
 - Contact
-  - Slack channel: #sig-observability @ [https://cloud-native.slack.com](https://cloud-native.slack.com)
-  - Email List: [cncf-sig-observability@lists.cncf.io](mailto:cncf-sig-observability@lists.cncf.io)
+  - Slack channel: #tag-observability @ [https://cloud-native.slack.com](https://cloud-native.slack.com)
+  - Email List: [cncf-tag-observability@lists.cncf.io](mailto:cncf-tag-observability@lists.cncf.io)
 - Meeting Schedule:
-  - TBD - pending feedback from SIG members
-  - [https://www.cncf.io/community/calendar](https://www.cncf.io/community/calendar/)
+  - Every 2nd Tuesday, 4pm - 5pm, UTC ([CNCF Calendar][cncfcal] for details)
+
+[cncfcal]: https://www.cncf.io/calendar


### PR DESCRIPTION
Use latest version by @halcyondude on from the [TOC repo](https://github.com/cncf/toc/blob/38f5a88e23e8bf27acc74f31d49f0090892e9050/tags/observability.md).

Expecting further updates and will likely either amend this commit or add another commit.

Also noteworthy: incorporates PR https://github.com/cncf/tag-observability/pull/45.

Edit: fixes issue https://github.com/cncf/tag-observability/issues/44.