### PR TITLE
Add WG Proposal Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/working-group-proposal.md
+++ b/.github/ISSUE_TEMPLATE/working-group-proposal.md
@@ -1,0 +1,31 @@
+---
+name: Working Group Proposal
+about: A sample template for working group proposals.
+title: WG-Proposal
+labels: pending-triage
+assignees: ''
+
+---
+
+**Description:** A short description of what the proposed WG is all about.
+
+**Impact:** The impact this WG will create.
+
+**Scope:** A draft of the initial scope that the WG will be looking into (suggestions)
+
+**WG Chairs/Leads Nominations (2/3):** Even though the WG is open to everyone we need 2-3 people to lead the efforts.
+
+**TAG Representative:** Someone from the TAG leadership team who will be coordinating all of these efforts and will help/guide wherever needed.
+
+**Diversity/Inclusivity Moderator (Optional):** Apart from the leadership team you should nominate a moderator who can review anything produced by the WG in any form and make sure it includes everyone.
+
+To Do:
+- [ ] WG Chair Nominee 1
+- [ ] WG Chair Nominee 2
+- [ ] TAG Representative
+- [ ] Moderator
+
+### A few things you should be aware of (you can remove this once you create the issue):
+Lifecycle of a proposal:
+
+**Proposal Created -> Triage -> WG Chairs Election -> Finalisation Of Scope -> Scope Presented at a TAG Meeting -> Review Period (A week or till the next meeting to make sure everyone gets a chance to review the scope) -> WIP -> Review -> Done -> Next Steps**


### PR DESCRIPTION
Added an issue template to propose new working groups. 
For more details please refer: https://github.com/cncf/tag-observability/issues/9