### PR TITLE
Add PromQL & KustoQL rubric.yaml

### DIFF
--- a/working-groups/query-standardization/dsls/kusto-query-language-metrics/rubric.yaml
+++ b/working-groups/query-standardization/dsls/kusto-query-language-metrics/rubric.yaml
@@ -1,0 +1,583 @@
+primitives:
+  rubric:
+    - DT1:
+        supported: true
+        notes: Supports integers of various sizes.
+    - DT2:
+        supported: true
+        notes: Supports unsigned integers.
+    - DT3:
+        supported: true
+        notes: Supports floating-point numbers.
+    - DT4:
+        supported: true
+        notes: Supports double-precision floating-point numbers.
+    - DT5:
+        supported: true
+        notes: Supports decimal data type.
+    - DT6:
+        supported: true
+        notes: Supports boolean data type.
+    - DT7:
+        supported: true
+        notes: Supports byte data type.
+    - DT8:
+        supported: true
+        notes: Supports DateTime data type.
+    - DT9:
+        supported: true
+        notes: Supports TimeSpan (duration) data type.
+    - DT10:
+        supported: true
+        notes: Supports null values.
+    - DT11:
+        supported: false
+    - DT12:
+        supported: false
+    - DT13:
+        supported: true
+        notes: Supports both ASCII and UTF-8 strings.
+    - DT14:
+        supported: true
+        notes: Supports binary data.
+    - DT15:
+        supported: true
+        notes: Supports arrays.
+    - DT16:
+        supported: true
+        notes: Supports dictionaries (maps).
+    - DT17:
+        supported: true
+        notes: Supports dynamic data type, allowing for nested structures.
+    - DT18:
+        supported: true
+        notes: Supports JSON data type.
+    - DT19:
+        supported: false
+    - UDT1:
+        supported: true
+        notes: Supports user-defined types via custom serialization.
+
+predicates:
+  rubric:
+    - P1:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/equalityoperator
+    - P2:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/notequaltooperator
+    - P3:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/lessthanoperator
+    - P4:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/greaterthanoperator
+    - P5:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/lessthanorequaltooperator
+    - P6:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/greaterthanorequaltooperator
+    - P7:
+        supported: true
+    - P8:
+        supported: true
+    - P9:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/inoperator
+    - P10:
+        supported: true
+    - P11:
+        supported: true
+    - P12:
+        supported: true
+    - P13:
+        supported: true
+    - P14:
+        supported: true
+        notes: >
+          Supports pattern matching using `has`, `!has`, `hasprefix`, `hassuffix`, and `contains`.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/stringoperators
+    - P15:
+        supported: true
+        notes: >
+          Supports regular expression matching using `matches regex`.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/regexpmatchfunction
+    - P16:
+        supported: true
+    - P17:
+        supported: true
+    - P18:
+        supported: true
+    - P19:
+        supported: true
+    - P20:
+        supported: true
+    - P21:
+        supported: true
+    - P22:
+        supported: true
+    - P23:
+        supported: true
+    - P24:
+        supported: true
+    - P25:
+        supported: true
+    - P26:
+        supported: true
+    - P27:
+        supported: true
+    - P28:
+        supported: true
+    - P29:
+        supported: true
+    - P30:
+        supported: true
+    - P31:
+        supported: true
+    - P32:
+        supported: true
+    - P33:
+        supported: true
+    - P34:
+        supported: true
+    - P35:
+        supported: true
+    - P36:
+        supported: true
+    - P37:
+        supported: true
+    - P38:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/andoperator
+    - P39:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/oroperator
+    - P40:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/notoperator
+    - P41:
+        supported: true
+    - P42:
+        supported: true
+    - P43:
+        supported: true
+    - P44:
+        supported: true
+    - P45:
+        supported: true
+    - P46:
+        supported: true
+
+  additional:
+    - name: true
+      description: >
+        A predicate that always returns true.
+    - name: false
+      description: >
+        A predicate that always returns false.
+
+selection:
+  rubric:
+    - S1:
+        supported: true
+        notes: >
+          Supports selection of data from tables, including time series data.
+    - S2:
+        supported: false
+    - S3:
+        supported: true
+        notes: >
+          Supports joining across different tables.
+    - S4:
+        supported: true
+        notes: >
+          Supports renaming columns using `project` and `extend`.
+
+math:
+  rubric:
+    - M1:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports addition of two columns or a column and a scalar.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/additionoperator
+    - M2:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports subtraction of two columns or a column and a scalar.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/subtractionoperator
+    - M3:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports multiplication of two columns or a column and a scalar.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/multiplicationoperator
+    - M4:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports division of two columns or a column and a scalar.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/divisionoperator
+    - M5:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports exponentiation using the `pow` function.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/powfunction
+    - M6:
+        supported: true
+        types:
+          - timeseries
+          - literals
+        notes: >
+          Supports negation of a column or a scalar.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/unaryminusoperator
+    - M7:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/sqrtfunction
+    - M8:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/modulusoperator
+
+conversion:
+  rubric:
+    - TP1:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/todatetimefunction
+
+joins:
+  rubric:
+    - J1:
+        supported: true
+        notes: Supports inner, leftouter, rightouter, and fullouter joins.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/joinoperator
+
+assignment:
+  rubric:
+    - A1:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/letstatement
+
+presentation:
+  rubric:
+    - PR1:
+        supported: true
+        notes: >
+          Supports various presentation functions, including rendering charts in the Azure Data Explorer web UI.
+
+aggregation:
+  rubric:
+    - F1:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/summarizeoperator
+    - F2:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/avg-aggfunction
+    - F3:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/min-aggfunction
+    - F4:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/max-aggfunction
+    - F5:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/count-aggfunction
+    - F6:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/stdev-aggfunction
+    - F7:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/percentiles-aggfunction
+
+grouping:
+  rubric:
+    - F8:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/summarizeoperator
+    - F9:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/orderoperator
+    - F10:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/takeoperator
+    - F11:
+        supported: true
+        notes: >
+          Supports pagination using `skip` and `take`.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/skipoperator
+    - F12:
+        supported: true
+        notes: >
+          Supports projection using `project`.
+
+windowing:
+  rubric:
+    - F13:
+        supported: true
+        notes: >
+          Supports time windowing using `bin`.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/binfunction
+    - F14:
+        supported: true
+        notes: >
+          Supports moving averages and sums.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/moving-avgfunction
+    - F15:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/binfunction
+    - F16:
+        supported: false
+    - F17:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/sumfunction
+    - F18:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/row_numberfunction
+    - F19:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/rankfunction
+    - F20:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/cdf-aggfunction
+    - F21:
+        supported: true
+    - F22:
+        supported: true
+    - F23:
+        supported: true
+
+conditional:
+  rubric:
+    - F24:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/coalescefunction
+    - F25:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/casefunction
+    - F26:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/tostringfunction
+    - F27:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/least-greatestfunctions
+
+math:
+  rubric:
+    - F29:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/absfunction
+    - F30:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/ceilfunction
+    - F31:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/floorfunction
+    - F32:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/logfunction
+    - F33:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/lnfunction
+    - F34:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/roundfunction
+    - F35:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/truncatefunction
+    - F36:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/trigonometricfunctions
+    - F37:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/randfunction
+    - F38:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/maketimefunction
+
+string:
+  rubric:
+    - F39:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/concatfunction
+    - F40:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/trimfunction
+    - F50:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/tolowerfunction
+    - F51:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/padleft-padrightfunctions
+    - F52:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/indexoffunction
+    - F53:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/substringfunction
+    - F54:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/regexpmatchfunction
+    - F55:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/replacefunction
+    - F56:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/splitfunction
+    - F57:
+        supported: true
+
+datetime:
+  rubric:
+    - F58:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/addtimespanfunction
+    - F59:
+        supported: true
+    - F60:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/nowfunction
+    - F61:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/binfunction
+    - F62:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/todatetimefunction
+    - F63:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/startofdayfunction
+    - F64:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/makedatetimefunction
+    - F65:
+        supported: true
+    - F66:
+        supported: true
+        notes: >
+          Supports converting strings to absolute or relative timestamps.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/todatetimefunction
+
+data_type_formatting:
+  rubric:
+    - F67:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/tostringfunction
+    - F68:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/tonumberfunction
+    - F69:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/todatetimefunction
+
+user_defined_functions:
+  rubric:
+    - UDF1:
+        supported: true
+        notes: >
+          Supports user-defined functions using the `function` keyword.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/functions/user-defined-functions
+
+observability_features:
+  rubric:
+    - F70:
+        supported: true
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/ago-function
+    - F71:
+        supported: true
+        notes: >
+          Supports interpolation using `make-series`.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/makeseriesoperator
+    - F72:
+        supported: true
+        notes: >
+          KustoQL handles absent data by defaulting to null or zero in some contexts.
+        references:
+          - https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/coalescefunction

--- a/working-groups/query-standardization/dsls/promql/rubric.yaml
+++ b/working-groups/query-standardization/dsls/promql/rubric.yaml
@@ -367,13 +367,19 @@ math:
     - F29:
         supported: true
         references:
-          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#abs
     - F30:
-        supported: false
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#ceil
     - F31:
-        supported: false
+       supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#floor
     - F32:
-        supported: false
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#log2
     - F33:
         supported: false
     - F34:

--- a/working-groups/query-standardization/dsls/promql/rubric.yaml
+++ b/working-groups/query-standardization/dsls/promql/rubric.yaml
@@ -1,0 +1,463 @@
+primitives:
+  rubric:
+    - DT1:
+        supported: true
+        notes: Literals only, cast to floats (double precision).
+    - DT2:
+        supported: false
+    - DT3:
+        supported: false
+    - DT4:
+        supported: true
+    - DT5:
+        supported: false
+    - DT6:
+        supported: false
+    - DT7:
+        supported: false
+    - DT8:
+        supported: false
+    - DT9:
+        supported: false
+    - DT10:
+        supported: false
+    - DT11:
+        supported: false
+    - DT12:
+        supported: false
+    - DT13:
+        supported: false
+        notes: >
+          Only ASCII is accepted for labels, but output can contain UTF-8.
+    - DT14:
+        supported: false
+    - DT15:
+        supported: false
+    - DT16:
+        supported: false
+    - DT17:
+        supported: false
+    - DT18:
+        supported: false
+    - DT19:
+        supported: false
+    - UDT1:
+        supported: false
+
+predicates:
+  rubric:
+    - P1:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P2:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P3:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P4:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P5:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P6:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P7:
+        supported: false
+    - P8:
+        supported: false
+    - P9:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P10:
+        supported: false
+    - P11:
+        supported: false
+    - P12:
+        supported: false
+    - P13:
+        supported: false
+    - P14:
+        supported: true
+        notes: >
+          Supports regular expression matches for label values.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P15:
+        supported: true
+        notes: >
+          Supports regular expression matches for label values.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+    - P16:
+        supported: false
+    - P17:
+        supported: false
+    - P18:
+        supported: false
+    - P19:
+        supported: false
+    - P20:
+        supported: false
+    - P21:
+        supported: false
+    - P22:
+        supported: false
+    - P23:
+        supported: false
+    - P24:
+        supported: false
+    - P25:
+        supported: false
+    - P26:
+        supported: false
+    - P27:
+        supported: false
+    - P28:
+        supported: false
+    - P29:
+        supported: false
+    - P30:
+        supported: false
+    - P31:
+        supported: false
+    - P32:
+        supported: false
+    - P33:
+        supported: false
+    - P34:
+        supported: false
+    - P35:
+        supported: false
+    - P36:
+        supported: false
+    - P37:
+        supported: false
+    - P38:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#binary-operators
+    - P39:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#binary-operators
+    - P40:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/basics/#binary-operators
+    - P41:
+        supported: false
+    - P42:
+        supported: false
+    - P43:
+        supported: false
+    - P44:
+        supported: false
+    - P45:
+        supported: false
+    - P46:
+        supported: false
+
+  additional:
+    - name: true
+      description: >
+        A predicate that always returns true.
+    - name: false
+      description: >
+        A predicate that always returns false.
+
+selection:
+  rubric:
+    - S1:
+        supported: true
+        notes: >
+          Prometheus supports querying metrics via instant and range vector selectors.
+    - S2:
+        supported: false
+        notes: >
+          Prometheus does not support querying different types (e.g., logs, traces) within the same query.
+    - S3:
+        supported: false
+    - S4:
+        supported: true
+        notes: >
+          Metrics can be renamed using the `label_replace` function.
+
+math:
+  rubric:
+    - M1:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports addition of two vectors or a vector and a scalar.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M2:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports subtraction of two vectors or a vector and a scalar.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M3:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports multiplication of two vectors or a vector and a scalar.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M4:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports division of two vectors or a vector and a scalar.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M5:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports exponentiation of a vector by a scalar.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M6:
+        supported: true
+        types:
+          - timeseries
+        notes: >
+          Supports negation of a vector.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#arithmetic-binary-operators
+    - M7:
+        supported: false
+    - M8:
+        supported: false
+
+conversion:
+  rubric:
+    - TP1:
+        supported: false
+
+joins:
+  rubric:
+    - J1:
+        supported: false
+        notes: Prometheus does not support traditional joins but supports binary operators to combine vectors.
+
+assignment:
+  rubric:
+    - A1:
+        supported: false
+
+presentation:
+  rubric:
+    - PR1:
+        supported: false
+        notes: >
+          Presentation aspects are handled outside PromQL, typically in visualization tools like Grafana.
+
+aggregation:
+  rubric:
+    - F1:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F2:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F3:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F4:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F5:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F6:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F7:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+
+grouping:
+  rubric:
+    - F8:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
+    - F9:
+        supported: false
+    - F10:
+        supported: false
+    - F11:
+        supported: false
+    - F12:
+        supported: true
+        notes: >
+          Supports implicit projection by metric name and labels.
+
+windowing:
+  rubric:
+    - F13:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F14:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F15:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F16:
+        supported: false
+    - F17:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F18:
+        supported: false
+    - F19:
+        supported: false
+    - F20:
+        supported: false
+    - F21:
+        supported: false
+    - F22:
+        supported: false
+    - F23:
+        supported: false
+
+conditional:
+  rubric:
+    - F24:
+        supported: false
+    - F25:
+        supported: false
+    - F26:
+        supported: false
+    - F27:
+        supported: false
+
+math:
+  rubric:
+    - F29:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time
+    - F30:
+        supported: false
+    - F31:
+        supported: false
+    - F32:
+        supported: false
+    - F33:
+        supported: false
+    - F34:
+        supported: false
+    - F35:
+        supported: false
+    - F36:
+        supported: false
+    - F37:
+        supported: false
+    - F38:
+        supported: false
+
+string:
+  rubric:
+    - F39:
+        supported: false
+    - F40:
+        supported: false
+    - F50:
+        supported: false
+    - F51:
+        supported: false
+    - F52:
+        supported: false
+    - F53:
+        supported: false
+    - F54:
+        supported: false
+    - F55:
+        supported: false
+    - F56:
+        supported: false
+    - F57:
+        supported: false
+
+datetime:
+  rubric:
+    - F58:
+        supported: false
+    - F59:
+        supported: false
+    - F60:
+        supported: false
+    - F61:
+        supported: false
+    - F62:
+        supported: false
+    - F63:
+        supported: false
+    - F64:
+        supported: false
+    - F65:
+        supported: false
+    - F66:
+        supported: false
+
+data_type_formatting:
+  rubric:
+    - F67:
+        supported: false
+    - F68:
+        supported: false
+    - F69:
+        supported: false
+
+user_defined_functions:
+  rubric:
+    - UDF1:
+        supported: false
+
+observability_features:
+  rubric:
+    - F70:
+        supported: true
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#offset
+    - F71:
+        supported: false
+    - F72:
+        supported: true
+        notes: >
+          PromQL handles absent data by defaulting to NaN or zero in some contexts.
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
+    - F73:
+        supported: false

--- a/working-groups/query-standardization/dsls/promql/rubric.yaml
+++ b/working-groups/query-standardization/dsls/promql/rubric.yaml
@@ -461,3 +461,9 @@ observability_features:
           - https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
     - F73:
         supported: false
+    - F74:
+        supported: false
+    - F75:
+        references:
+          - https://prometheus.io/docs/prometheus/latest/querying/functions/#rate()
+        supported: true


### PR DESCRIPTION
Ref: https://prometheus.io/docs/prometheus/latest/querying/basics/

There are several features and functions in PromQL that are supported but not mentioned in the rubric template.

### Functions

- irate(): Calculates the per-second instant rate of increase of the time series.
- increase(): Calculates the increase in the time series in the specified time range.
- delta(): Calculates the difference between the first and last value in the specified time range.
- deriv(): Calculates the per-second derivative of the time series.
- idelta(): Calculates the per-second instant difference between the first and last value in the specified time range.
- resets(): Counts the number of times the value of the time series resets (i.e., goes down).
- changes(): Counts the number of times the value of the time series changes.


### Vector Matching
PromQL supports vector matching to combine multiple time series based on their labels using binary operators.
 